### PR TITLE
Transition scale: Vector2 => Vector3.

### DIFF
--- a/Scripts/Runtime/SimpleScrollSnap.cs
+++ b/Scripts/Runtime/SimpleScrollSnap.cs
@@ -545,10 +545,10 @@ namespace DanielLochner.Assets.SimpleScrollSnap
                             panel.transform.localPosition = new Vector3(panel.transform.localPosition.x, panel.transform.localPosition.y, transitionEffect.GetValue(displacement));
                             break;
                         case "localScale.x":
-                            panel.transform.localScale = new Vector2(transitionEffect.GetValue(displacement), panel.transform.localScale.y);
+                            panel.transform.localScale = new Vector3(transitionEffect.GetValue(displacement), panel.transform.localScale.y, panel.transform.localScale.z);
                             break;
                         case "localScale.y":
-                            panel.transform.localScale = new Vector2(panel.transform.localScale.x, transitionEffect.GetValue(displacement));
+                            panel.transform.localScale = new Vector3(panel.transform.localScale.x, transitionEffect.GetValue(displacement), panel.transform.localScale.z);
                             break;
                         case "localRotation.x":
                             panel.transform.localRotation = Quaternion.Euler(new Vector3(transitionEffect.GetValue(displacement), panel.transform.localEulerAngles.y, panel.transform.localEulerAngles.z));


### PR DESCRIPTION
Implicit conversion from Vector2 to Vector3 will have the scale z-component set to zero. Sometimes you need it. Specifically, this fixes an issue when you use UI particle effects from https://github.com/mob-sakai/UIEffect