### PR TITLE
Bugfix: Adding a slide after initialization causes slide anchor positions to misalign when InfiniteScrolling is enabled

### DIFF
--- a/Scripts/Core/Runtime/Behaviours/SimpleScrollSnap.cs
+++ b/Scripts/Core/Runtime/Behaviours/SimpleScrollSnap.cs
@@ -412,7 +412,7 @@ namespace DanielLochner.Assets.SimpleScrollSnap
             float xOffset = (movementType == MovementType.Free || movementAxis == MovementAxis.Horizontal) ? Viewport.rect.width  / 2f : 0f;
             float yOffset = (movementType == MovementType.Free || movementAxis == MovementAxis.Vertical)   ? Viewport.rect.height / 2f : 0f;
             Vector2 offset = new Vector2(xOffset, yOffset);
-            prevAnchoredPosition = Content.anchoredPosition = -Panels[startingPanel].anchoredPosition + offset;
+            prevAnchoredPosition = Content.anchoredPosition;
             SelectedPanel = CenteredPanel = startingPanel;
 
             // Buttons


### PR DESCRIPTION
There is a bug with the 'Dynamic Content' example in the Unity package. When I enable InfiniteScrolling and try to add a slide after initialization, the selected slide is no longer centered. 

I believe I found the issue is due to a modification of anchorPosition after the InfiniteScrolling handler function is called, which itself depends on the Panels' anchorPositions. This will a result in a misalignment of anchorPositions. This can be easily solved by avoiding offsetting the Panel in SetUp() as doing so does not appear to cause any adverse affects at least in the examples provided. 